### PR TITLE
Adjust Tips Proportionally in Partial Fills

### DIFF
--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -368,6 +368,7 @@ export function fulfillStandardOrder(
     ? mapOrderAmountsFromUnitsToFill(order, {
         unitsToFill,
         totalSize,
+        tips
       })
     : // Else, we adjust the order by the remaining order left to be fulfilled
       mapOrderAmountsFromFilledStatus(order, {

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -380,6 +380,8 @@ export function fulfillStandardOrder(
     parameters: { offer, consideration },
   } = orderWithAdjustedFills;
 
+  console.log("orderWithAdjustedFills", orderWithAdjustedFills);
+
   const considerationIncludingTips = [...consideration];
 
   const offerCriteriaItems = offer.filter(({ itemType }) =>

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -380,7 +380,7 @@ export function fulfillStandardOrder(
     parameters: { offer, consideration },
   } = orderWithAdjustedFills;
 
-  const considerationIncludingTips = [...consideration, ...tips];
+  const considerationIncludingTips = [...consideration];
 
   const offerCriteriaItems = offer.filter(({ itemType }) =>
     isCriteriaItem(itemType),

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -368,7 +368,7 @@ export function fulfillStandardOrder(
     ? mapOrderAmountsFromUnitsToFill(order, {
         unitsToFill,
         totalSize,
-        tips
+        tips,
       })
     : // Else, we adjust the order by the remaining order left to be fulfilled
       mapOrderAmountsFromFilledStatus(order, {
@@ -572,6 +572,7 @@ export function fulfillAvailableOrders({
         ? mapOrderAmountsFromUnitsToFill(orderMetadata.order, {
             unitsToFill: orderMetadata.unitsToFill,
             totalSize: orderMetadata.orderStatus.totalSize,
+            tips: orderMetadata.tips,
           })
         : // Else, we adjust the order by the remaining order left to be fulfilled
           mapOrderAmountsFromFilledStatus(orderMetadata.order, {

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -224,7 +224,8 @@ export const mapOrderAmountsFromUnitsToFill = (
   {
     unitsToFill,
     totalSize,
-  }: { unitsToFill: BigNumberish; totalSize: BigNumber },
+    tips = [] 
+  }: { unitsToFill: BigNumberish; totalSize: BigNumber, tips: ConsiderationItem[]; },
 ): Order => {
   const unitsToFillBn = BigNumber.from(unitsToFill);
 
@@ -238,6 +239,34 @@ export const mapOrderAmountsFromUnitsToFill = (
     totalSize = maxUnits;
   }
 
+  const adjustedTips = tips.map((tip) => ({
+    ...tip,
+    startAmount: multiplyDivision(
+      tip.startAmount,
+      unitsToFillBn,
+      totalSize,
+    ).toString(),
+    endAmount: multiplyDivision(
+      tip.endAmount,
+      unitsToFillBn,
+      totalSize,
+    ).toString(),
+  }));
+
+  const adjustedConsideration = order.parameters.consideration.map((item) => ({
+    ...item,
+    startAmount: multiplyDivision(
+      item.startAmount,
+      unitsToFillBn,
+      totalSize,
+    ).toString(),
+    endAmount: multiplyDivision(
+      item.endAmount,
+      unitsToFillBn,
+      totalSize,
+    ).toString(),
+  }));
+  
   return {
     parameters: {
       ...order.parameters,
@@ -254,19 +283,7 @@ export const mapOrderAmountsFromUnitsToFill = (
           totalSize,
         ).toString(),
       })),
-      consideration: order.parameters.consideration.map((item) => ({
-        ...item,
-        startAmount: multiplyDivision(
-          item.startAmount,
-          unitsToFillBn,
-          totalSize,
-        ).toString(),
-        endAmount: multiplyDivision(
-          item.endAmount,
-          unitsToFillBn,
-          totalSize,
-        ).toString(),
-      })),
+      consideration: [...adjustedConsideration, ...adjustedTips]
     },
     signature: order.signature,
   };

--- a/test/utils/balance.ts
+++ b/test/utils/balance.ts
@@ -112,6 +112,7 @@ export const verifyBalancesAfterFulfill = async ({
     ? mapOrderAmountsFromUnitsToFill(order, {
         unitsToFill,
         totalSize,
+        tips: [],
       })
     : mapOrderAmountsFromFilledStatus(order, {
         totalFilled,


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

This pull request addresses an inconsistency in the Seaport SDK where tips were not being adjusted proportionally during partial fills of an order, unlike consideration items. This inconsistency could lead to inaccurate tip calculations in scenarios involving partial order fulfillment.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Extended the mapOrderAmountsFromUnitsToFill function to include logic for adjusting tips based on the unitsToFill.
Merged the adjusted tips with the consideration items, ensuring that both are handled uniformly during partial fills.
Ensured that these adjustments are accurately reflected in the final order object returned by the function.
